### PR TITLE
Use * after DeclareMathOperator to have limits go under argmax/min

### DIFF
--- a/sty/shortcuts_js.sty
+++ b/sty/shortcuts_js.sty
@@ -244,8 +244,8 @@
 \newcommand{\Beta}{\mathrm{B}}
 
 
-\newcommand{\argmin}{\mathop{\mathrm{arg\,min}}}
-\newcommand{\argmax}{\mathop{\mathrm{arg\,max}}}
+\DeclareMathOperator*{\argmin}{\mathrm{arg\,min}}
+\DeclareMathOperator*{\argmax}{\mathrm{arg\,max}}
 \def\essinf{\mathop{\rm ess\, inf}}
 \def\esssup{\mathop{\rm ess\, sup}}
 \def\supp{\mathop{\rm supp}}

--- a/sty/shortcuts_js.sty
+++ b/sty/shortcuts_js.sty
@@ -244,8 +244,8 @@
 \newcommand{\Beta}{\mathrm{B}}
 
 
-\DeclareMathOperator*{\argmin}{\mathrm{arg\,min}}
-\DeclareMathOperator*{\argmax}{\mathrm{arg\,max}}
+\DeclareMathOperator*{\argmin}{arg\,min}
+\DeclareMathOperator*{\argmax}{arg\,max}
 \def\essinf{\mathop{\rm ess\, inf}}
 \def\esssup{\mathop{\rm ess\, sup}}
 \def\supp{\mathop{\rm supp}}


### PR DESCRIPTION
It seems that this is the standard way to do it:
https://tex.stackexchange.com/questions/5223/command-for-argmin-or-argmax

It harmonizes with other declarations above
@josephsalmon 