### PR TITLE
Make beamer_js compile

### DIFF
--- a/tex/sty/beamer_js.sty
+++ b/tex/sty/beamer_js.sty
@@ -68,21 +68,21 @@
 \AdaptNoteOpt\footfullcite\multfootfullcite
 
 
-% Configure style for custom doubled line
-\newcommand*{\doublerule}{\hrule width \hsize height 1pt \kern 0.5mm \hrule width \hsize height 2pt}
+% % Configure style for custom doubled line
+% \newcommand*{\doublerule}{\hrule width \hsize height 1pt \kern 0.5mm \hrule width \hsize height 2pt}
 
-% Configure function to fill line with doubled line
-\newcommand\doublerulefill{\leavevmode\leaders\vbox{\hrule width .1pt\kern1pt\hrule}\hfill\kern0pt }
+% % Configure function to fill line with doubled line
+% \newcommand\doublerulefill{\leavevmode\leaders\vbox{\hrule width .1pt\kern1pt\hrule}\hfill\kern0pt }
 
 
-\newcommand{\mytheorem}[2]{
-\doublerulefill\ \framebox{\textbf{#1}}\ \doublerulefill
-\vspace{0.1cm}
+% \newcommand{\mytheorem}[2]{
+% \doublerulefill\ \framebox{\textbf{#1}}\ \doublerulefill
+% \vspace{0.1cm}
 
-#2
+% #2
 
-\doublerulefill
-}
+% \doublerulefill
+% }
 
 
 


### PR DESCRIPTION
Currently `beamer_js.tex` is not compiling because of duplicated import in `beamer_js.sty` and `shortcut_js.sty`.
I commented the duplicated imports and `beamer_js.tex is now compiling.

solves #28 